### PR TITLE
Fix: CodeBlock module import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "herokwon-ds",
-  "version": "1.6.4",
+  "name": "herokwon-test",
+  "version": "0.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "herokwon-ds",
-      "version": "1.6.4",
+      "name": "herokwon-test",
+      "version": "0.1.26",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.4"
@@ -42,6 +42,7 @@
         "@types/react-dom": "^18",
         "@types/rollup-plugin-peer-deps-external": "^2.2.5",
         "autoprefixer": "^10.4.20",
+        "babel-plugin-prismjs": "^2.1.0",
         "chromatic": "^11.7.1",
         "eslint": "^8",
         "eslint-config-next": "14.2.6",
@@ -7295,6 +7296,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-prismjs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-prismjs/-/babel-plugin-prismjs-2.1.0.tgz",
+      "integrity": "sha512-ehzSKYfeAz4U78zi/sfwsjDPlq0LvDKxNefcZTJ/iKBu+plsHsLqZhUeGf1+82LAcA35UZGbU6ksEx2Utphc/g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prismjs": "^1.18.0"
       }
     },
     "node_modules/balanced-match": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@types/react-dom": "^18",
     "@types/rollup-plugin-peer-deps-external": "^2.2.5",
     "autoprefixer": "^10.4.20",
+    "babel-plugin-prismjs": "^2.1.0",
     "chromatic": "^11.7.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.6",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -3,14 +3,14 @@ import commonjs from '@rollup/plugin-commonjs';
 import image from '@rollup/plugin-image';
 import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
-import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import postcss from 'rollup-plugin-postcss';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import autoprefixer from 'autoprefixer';
 import cssimport from 'postcss-import';
-import pkg from './package.json' assert { type: 'json' };
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import postcss from 'rollup-plugin-postcss';
 import tailwindcss from 'tailwindcss';
+import pkg from './package.json' assert { type: 'json' };
 
 const extensions = ['.mjs', '.js', '.jsx', '.ts', '.tsx'];
 
@@ -47,6 +47,12 @@ const config = [
         ],
         plugins: [
           '@babel/plugin-transform-runtime',
+          [
+            'prismjs', {
+              'languages': 'all',
+              'plugins': ['autoloader'],
+            },
+          ],
         ],
         extensions: extensions,
         include: ['src/**/*'],

--- a/src/components/ui/Code.tsx
+++ b/src/components/ui/Code.tsx
@@ -8,7 +8,7 @@ export default function Code({ children, ...props }: CodeProps) {
   return (
     <code
       {...props}
-      className={`inline rounded-ms bg-light-tertiary px-0.5 font-medium dark:bg-dark-tertiary ${props.className ?? ''}`}
+      className={`inline rounded-ms bg-light-tertiary px-1.5 font-medium dark:bg-dark-tertiary ${props.className ?? ''}`}
     >
       {children}
     </code>

--- a/src/components/ui/CodeBlock.stories.tsx
+++ b/src/components/ui/CodeBlock.stories.tsx
@@ -1,4 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import dynamic from 'next/dynamic';
+import { highlightAll } from 'prismjs';
+import { useEffect } from 'react';
 
 import { CODE_LANGUAGES } from '../../data/constants';
 
@@ -35,26 +38,49 @@ export default function CodeBlockExample({ code }: CodeBlockProps) {
 } satisfies Meta<typeof CodeBlock>;
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof CodeBlock>;
 
-export const Default: Story = {};
+const CodeBlockComponent = dynamic(() =>
+  import('prismjs').then(() => CodeBlock),
+);
+
+const CodeBlockRender = ({
+  language,
+  code,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof CodeBlock>) => {
+  useEffect(() => {
+    try {
+      if (language === 'tsx') {
+        require('prismjs/components/prism-typescript');
+        require('prismjs/components/prism-jsx');
+        require('prismjs/components/prism-tsx');
+      } else require(`prismjs/components/prism-${language}`);
+      highlightAll();
+    } catch (error: unknown) {
+      console.error(error);
+    }
+  }, [language, code]);
+
+  return <CodeBlockComponent language={language} code={code} {...props} />;
+};
+
+export const Default: Story = {
+  render: ({ ...props }) => <CodeBlockRender {...props} />,
+};
 
 export const Highlight: Story = {
   args: {
     highlights: [9],
   },
+  render: ({ ...props }) => <CodeBlockRender {...props} />,
 };
 
 export const Label: Story = {
   args: {
     label: 'example.tsx',
   },
-};
-
-export const LineNumbers: Story = {
-  args: {
-    showLineNumbers: true,
-  },
+  render: ({ ...props }) => <CodeBlockRender {...props} />,
 };
 
 export const FirstLineNumber: Story = {
@@ -63,6 +89,7 @@ export const FirstLineNumber: Story = {
     firstLineNumber: 100,
     highlights: [108],
   },
+  render: ({ ...props }) => <CodeBlockRender {...props} />,
 };
 
 export const Hidable: Story = {
@@ -70,4 +97,5 @@ export const Hidable: Story = {
     isHidable: true,
     hidableFirstNumber: 11,
   },
+  render: ({ ...props }) => <CodeBlockRender {...props} />,
 };

--- a/src/components/ui/CodeBlock.tsx
+++ b/src/components/ui/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import * as Prism from 'prismjs';
+import { highlightAll } from 'prismjs';
 import { Fragment, useEffect } from 'react';
 import { FaChevronDown } from 'react-icons/fa6';
 import { LuCopy } from 'react-icons/lu';
@@ -47,16 +47,7 @@ export default function CodeBlock({
     code.length === 0 ? 0 : (code.match(/\n/g)?.length ?? 0) + 1;
 
   useEffect(() => {
-    try {
-      if (language === 'tsx') {
-        require('prismjs/components/prism-typescript');
-        require('prismjs/components/prism-jsx');
-        require('prismjs/components/prism-tsx');
-      } else require(`prismjs/components/prism-${language}`);
-      Prism.highlightAll();
-    } catch (error: unknown) {
-      console.error(error);
-    }
+    highlightAll();
   }, [language, code]);
 
   return (
@@ -141,7 +132,7 @@ export default function CodeBlock({
               icon={FaChevronDown}
               variant="secondary"
               shape="square"
-              className="absolute bottom-0 left-1/2 z-0 w-full -translate-x-1/2 rounded-t-none bg-gradient-to-b from-transparent to-dark-primary py-1 text-dark transition-colors only:*:transition-transform hover:!bg-transparent group-[.showing]:mb-2 group-[.showing]:bg-none group-[.showing]:only:*:rotate-180 hover:group-[.showing]:!bg-dark-tertiary/off"
+              className="absolute bottom-0 left-1/2 z-0 w-full -translate-x-1/2 rounded-t-none bg-gradient-to-b from-transparent to-dark-primary py-1 text-dark transition-colors only:*:transition-transform hover:!bg-transparent group-[.showing]:bg-none group-[.showing]:pb-3 group-[.showing]:only:*:rotate-180 hover:group-[.showing]:!bg-dark-tertiary/off"
               onClick={e =>
                 e.currentTarget.parentElement?.classList.toggle('showing')
               }

--- a/src/configs/plugin.ts
+++ b/src/configs/plugin.ts
@@ -158,7 +158,9 @@ export default plugin(function ({
     },
 
     'code[class*="language-"]': {
+      width: '100%',
       padding: '0.5rem 1rem',
+      'box-sizing': 'content-box',
       'background-color': '#1E293B',
     },
   });


### PR DESCRIPTION
## 연관 이슈
#131 

<br />

## 작업 개요
> CodeBlock 컴포넌트 관련 모듈 참조 오류 수정

<br />

## 상세 내용
- [x] [**_babel-plugin-prismjs_**](https://github.com/mAAdhaTTah/babel-plugin-prismjs) 라이브러리 추가
- [x] rollup : babel 플러그인 prismjs 설정 추가
- [x] **`CodeBlock`** : 컴포넌트에서의 스크립트 참조 제거
- [x] **`Code`** : padding 스타일 변경
